### PR TITLE
Add Junctions non-collision states

### DIFF
--- a/src/main/scala/pl/edu/pw/elka/knowledgeDatabase/Junction.java
+++ b/src/main/scala/pl/edu/pw/elka/knowledgeDatabase/Junction.java
@@ -1,10 +1,24 @@
 package pl.edu.pw.elka.knowledgeDatabase;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import pl.edu.pw.elka.enums.TrafficLightStates;
 
-import java.util.HashSet;
+public abstract class Junction {
+	protected final HashMap<TrafficLightStates, HashSet<TrafficLightStates>> states = new HashMap<>();
 
-interface Junction {
-    boolean isAllowed(final TrafficLightStates key1, final TrafficLightStates key2);
-    HashSet<TrafficLightStates> allowedStates(final TrafficLightStates key1);
+	protected abstract void initializeAllowedStates();
+
+	public Junction() {
+
+	}
+
+	public boolean isAllowed(final TrafficLightStates key1, final TrafficLightStates key2) {
+		return states.get(key1).contains(key2);
+	}
+
+	public HashSet<TrafficLightStates> allowedStates(final TrafficLightStates key1) {
+		return states.get(key1);
+	}
+
 }

--- a/src/main/scala/pl/edu/pw/elka/knowledgeDatabase/Junction.java
+++ b/src/main/scala/pl/edu/pw/elka/knowledgeDatabase/Junction.java
@@ -9,10 +9,6 @@ public abstract class Junction {
 
 	protected abstract void initializeAllowedStates();
 
-	public Junction() {
-
-	}
-
 	public boolean isAllowed(final TrafficLightStates key1, final TrafficLightStates key2) {
 		return states.get(key1).contains(key2);
 	}

--- a/src/main/scala/pl/edu/pw/elka/knowledgeDatabase/XJunction.java
+++ b/src/main/scala/pl/edu/pw/elka/knowledgeDatabase/XJunction.java
@@ -6,7 +6,6 @@ import pl.edu.pw.elka.enums.TrafficLightStates;
 
 class XJunction extends Junction {
 	XJunction() {
-		super();
 		initializeAllowedStates();
 	}
 

--- a/src/main/scala/pl/edu/pw/elka/knowledgeDatabase/XJunction.java
+++ b/src/main/scala/pl/edu/pw/elka/knowledgeDatabase/XJunction.java
@@ -1,30 +1,37 @@
 package pl.edu.pw.elka.knowledgeDatabase;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import pl.edu.pw.elka.enums.TrafficLightStates;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
+class XJunction extends Junction {
+	XJunction() {
+		super();
+		initializeAllowedStates();
+	}
 
-class XJunction implements Junction{
-    HashMap<TrafficLightStates, HashSet<TrafficLightStates>> states = new HashMap<>();
-    XJunction(){
-        //        A
-        states.put(TrafficLightStates.A_L, new HashSet<>(Arrays.asList(TrafficLightStates.A_P, TrafficLightStates.C_L, TrafficLightStates.D_P)));
-        states.put(TrafficLightStates.A_P, new HashSet<>(Arrays.asList(TrafficLightStates.A_L, TrafficLightStates.C_P, TrafficLightStates.B_L)));
-        //        B
-        //        todo
-        //        C
-        //        todo
-        //        D
-        //        todo
-    }
-    @Override
-    public boolean isAllowed(final TrafficLightStates key1, final TrafficLightStates key2){
-        return states.get(key1).contains(key2);
-    }
-    @Override
-    public HashSet<TrafficLightStates> allowedStates(final TrafficLightStates key1) {
-        return states.get(key1);
-    }
+	@Override
+	protected void initializeAllowedStates() {
+		// A
+		this.states.put(TrafficLightStates.A_L,
+				new HashSet<>(Arrays.asList(TrafficLightStates.A_P, TrafficLightStates.C_L, TrafficLightStates.D_P)));
+		this.states.put(TrafficLightStates.A_P,
+				new HashSet<>(Arrays.asList(TrafficLightStates.A_L, TrafficLightStates.C_P, TrafficLightStates.B_L)));
+		// B
+		this.states.put(TrafficLightStates.B_L,
+				new HashSet<>(Arrays.asList(TrafficLightStates.B_L, TrafficLightStates.D_L, TrafficLightStates.A_P)));
+		this.states.put(TrafficLightStates.B_P,
+				new HashSet<>(Arrays.asList(TrafficLightStates.B_L, TrafficLightStates.D_P, TrafficLightStates.C_L)));
+		// C
+		this.states.put(TrafficLightStates.C_L,
+				new HashSet<>(Arrays.asList(TrafficLightStates.C_P, TrafficLightStates.A_L, TrafficLightStates.B_P)));
+		this.states.put(TrafficLightStates.C_P,
+				new HashSet<>(Arrays.asList(TrafficLightStates.C_L, TrafficLightStates.A_P, TrafficLightStates.D_L)));
+		// D
+		this.states.put(TrafficLightStates.D_L,
+				new HashSet<>(Arrays.asList(TrafficLightStates.D_P, TrafficLightStates.B_L, TrafficLightStates.C_P)));
+		this.states.put(TrafficLightStates.D_P,
+				new HashSet<>(Arrays.asList(TrafficLightStates.D_L, TrafficLightStates.B_P, TrafficLightStates.A_L)));
+	}
+
 }

--- a/src/main/scala/pl/edu/pw/elka/knowledgeDatabase/YJunction.java
+++ b/src/main/scala/pl/edu/pw/elka/knowledgeDatabase/YJunction.java
@@ -1,17 +1,26 @@
 package pl.edu.pw.elka.knowledgeDatabase;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import pl.edu.pw.elka.enums.TrafficLightStates;
 
-import java.util.HashSet;
+class YJunction extends Junction {
+	public YJunction() {
+		super();
+	}
 
-class YJunction implements Junction{
-    @Override
-    public boolean isAllowed(TrafficLightStates key1, TrafficLightStates key2) {
-        return false;
-    }
-
-    @Override
-    public HashSet<TrafficLightStates> allowedStates(TrafficLightStates key1) {
-        return null;
-    }
+	@Override
+	protected void initializeAllowedStates() {
+		// A
+		this.states.put(TrafficLightStates.A_P, new HashSet<>(Collections.singletonList(TrafficLightStates.B_P)));
+		// B
+		this.states.put(TrafficLightStates.B_L, new HashSet<>(Arrays.asList(TrafficLightStates.C_P, TrafficLightStates.B_P)));
+		this.states.put(TrafficLightStates.B_P,
+				new HashSet<>(Arrays.asList(TrafficLightStates.A_P, TrafficLightStates.C_P, TrafficLightStates.B_L)));
+		// C
+		this.states.put(TrafficLightStates.C_L, new HashSet<>(Collections.singletonList(TrafficLightStates.C_P)));
+		this.states.put(TrafficLightStates.C_P,
+				new HashSet<>(Arrays.asList(TrafficLightStates.C_L, TrafficLightStates.B_P, TrafficLightStates.B_L)));
+	}
 }


### PR DESCRIPTION
Niektóre stany są bezkolizyjne tylko, jeśli jedzie się odpowiednim pasem (np. A_L i D_P - A_L musi jechac skrajnym lewym, D_P środkowym/skrajnym prawym by było bezkolizyjnie). 